### PR TITLE
add first sig file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.gz filter=lfs diff=lfs merge=lfs -text
+*.sig filter=lfs diff=lfs merge=lfs -text

--- a/sigs/flare_msvc_rtf/flare_msvc_rtf_32_64.sig
+++ b/sigs/flare_msvc_rtf/flare_msvc_rtf_32_64.sig
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b209857c583c26f68569e5eacb38e8cb4c9a1262a4ab8d1840836b8788ac3f78
+size 3921376

--- a/sigs/flare_msvc_rtf/flare_msvc_rtf_32_64_logs.tar.gz
+++ b/sigs/flare_msvc_rtf/flare_msvc_rtf_32_64_logs.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ad168494a7033610a9b89e3d9d1c38c907bff3cdf2e2dd01dc8338bfb6756b8
+size 5128930


### PR DESCRIPTION
Adding a signature file for MSVC run-time functions for 32 and 64 bit.

Rough stats (created using diff 🤣) compared to IDA sigs running on capa-testfiles using `match_flirt`

EDIT: excluded ATl and MFC IDA signatures from IDA results

functions | percentage
--- | ---
same IDA vs. FLARE | **72%**
recognized as lib by FLARE but no name, name in IDA | **16%**
not recognized by FLARE, recognized by IDA | **12%**
not recognized by IDA, regocnized by FLARE | **6%**

For the purpose within capa this looks like a good start!

Generation details (`create_sig` 4bc6196)
```
$ ../venv/Scripts/python create_sig.py -d -e libraries -ip libc msvc libvc vcruntime libucrt legacy_ oldnames libcon -s flare_msvc_rtf_32_64.sig -n "FLARE MSVC Signatures" -lr \\\$LN -lr label --tarballs-root data/ -- flare_msvc_rtf
INFO:__main__:creating output directory flare_msvc_rtf
INFO:__main__:collecting tarball paths
DEBUG:__main__: [-] skipping data/libraries\cryptopp\x64-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\cryptopp\x64-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\cryptopp\x64-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\cryptopp\x86-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\cryptopp\x86-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\cryptopp\x86-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\curl\x64-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\curl\x64-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\curl\x64-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\curl\x86-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\curl\x86-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\curl\x86-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\detours\x64-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\detours\x64-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\detours\x64-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\detours\x86-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\detours\x86-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\detours\x86-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\mbedtls\x64-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\mbedtls\x64-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\mbedtls\x64-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\mbedtls\x86-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\mbedtls\x86-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\mbedtls\x86-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\openssl\x64-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\openssl\x64-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\openssl\x64-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\openssl\x86-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\openssl\x86-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\openssl\x86-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\zlib\x64-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\zlib\x64-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\zlib\x64-windows-static-v142.tar.gz
DEBUG:__main__: [-] skipping data/libraries\zlib\x86-windows-static-v140.tar.gz
DEBUG:__main__: [-] skipping data/libraries\zlib\x86-windows-static-v141.tar.gz
DEBUG:__main__: [-] skipping data/libraries\zlib\x86-windows-static-v142.tar.gz
DEBUG:__main__:extracting from data/VS10\VS10.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS10\VS10_amd64.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS10-VC-lib-amd64-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS11\VS11.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS11\VS11_amd64.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS11-VC-lib-amd64-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS12\VS12.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS12\VS12_amd64.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS12-VC-lib-amd64-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS2015\compiler\14.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-vcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-vcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-oldnames.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcurtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-legacy_stdio_wide_specifiers.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-legacy_stdio_definitions.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-vcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-vcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-oldnames.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcurtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-legacy_stdio_wide_specifiers.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.0-lib-amd64-legacy_stdio_definitions.lib.pat
DEBUG:__main__:extracting from data/VS2015\ucrt\10.0.10240.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\10.0.10240.0-ucrt-x64-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.10240.0-ucrt-x64-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.10240.0-ucrt-x86-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.10240.0-ucrt-x86-libucrtd.lib.pat
DEBUG:__main__:extracting from data/VS2017\compiler\14.16.27023.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-vcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-vcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-vcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-vcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-oldnames.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcurtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-oldnames.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcurtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-legacy_stdio_wide_specifiers.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x86-legacy_stdio_definitions.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-legacy_stdio_wide_specifiers.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.16.27023-lib-x64-legacy_stdio_definitions.lib.pat
DEBUG:__main__:extracting from data/VS2017\ucrt\10.0.16299.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-ucrt-x86-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-ucrt-x86-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-ucrt-x64-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-ucrt-x64-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-um-x64-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-um-x64-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-um-x64-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-um-x86-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-um-x86-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.16299.0-um-x86-wsmsvc.lib.pat
DEBUG:__main__:extracting from data/VS2017\ucrt\10.0.17134.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-ucrt-x86-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-ucrt-x86-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-ucrt-x64-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-ucrt-x64-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-um-x64-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-um-x64-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-um-x86-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-um-x86-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-um-x64-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17134.0-um-x86-wsmsvc.lib.pat
DEBUG:__main__:extracting from data/VS2017\ucrt\10.0.17763.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-um-x64-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-um-x64-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-um-x64-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-um-x86-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-um-x86-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-um-x86-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-ucrt-x86-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-ucrt-x86-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-ucrt-x64-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.17763.0-ucrt-x64-libucrt.lib.pat
DEBUG:__main__:extracting from data/VS2019\compiler\14.28.29910.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-vcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-vcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-plegacy_stdio_float_rounding.obj.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-oldnames.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcurt_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcurtd_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcurtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcmrt_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcmrtd_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libvcasand.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libvcasan.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-legacy_stdio_wide_specifiers.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-legacy_stdio_float_rounding.obj.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x64-legacy_stdio_definitions.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-vcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-vcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-plegacy_stdio_float_rounding.obj.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-oldnames.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcurt_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcurtd_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcurtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcmrt_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcmrtd_netcore.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libvcruntimed.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libvcruntime.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libvcasand.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libvcasan.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcpmtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcpmtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcpmt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrtd1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrtd0.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrt1.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libconcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-legacy_x86_flt_exceptions.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-legacy_stdio_wide_specifiers.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-legacy_stdio_float_rounding.obj.pat
DEBUG:__main__: writing flare_msvc_rtf\14.28.29910-lib-x86-legacy_stdio_definitions.lib.pat
DEBUG:__main__:extracting from data/VS2019\ucrt\10.0.18362.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-ucrt-x86-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-ucrt-x86-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-ucrt-x64-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-ucrt-x64-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-um-x64-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-um-x64-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-um-x64-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-um-x86-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-um-x86-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.18362.0-um-x86-ntstc_libcmt.lib.pat
DEBUG:__main__:extracting from data/VS2019\ucrt\10.0.19041.0.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-um-x86-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-um-x86-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-um-x86-ntstc_libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-ucrt-x64-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-ucrt-x64-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-ucrt-x86-libucrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-ucrt-x86-libucrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-um-x64-wsmsvc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-um-x64-ntstc_msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\10.0.19041.0-um-x64-ntstc_libcmt.lib.pat
DEBUG:__main__:extracting from data/VS6\VS6.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libc.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcimt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcimtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcp.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcpd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS6-vc98-lib-msvcrtd.lib.pat
DEBUG:__main__:extracting from data/VS8\VS8.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS8\VS8_amd64.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS8-VC-lib-amd64-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS9\VS9.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-msvcurtd.lib.pat
DEBUG:__main__:extracting from data/VS9\VS9_amd64.tar.gz
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-libcmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-libcmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-libcpmt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-libcpmtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcmrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcmrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcprt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcprtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcrt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcrtd.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcurt.lib.pat
DEBUG:__main__: writing flare_msvc_rtf\VS9-VC-lib-amd64-msvcurtd.lib.pat
INFO:__main__:creating sig file flare_msvc_rtf_32_64.sig
DEBUG:__main__:creating temporary pat files
DEBUG:__main__:running sigmake_patched.exe -v -v -n"FLARE MSVC Signatures" -lr\$LN -lrlabel flare_msvc_rtf\0.pat flare_msvc_rtf\1.pat flare_msvc_rtf\2.pat flare_msvc_rtf\3.
pat flare_msvc_rtf\4.pat flare_msvc_rtf\5.pat flare_msvc_rtf\6.pat flare_msvc_rtf\7.pat flare_msvc_rtf\8.pat flare_msvc_rtf\9.pat flare_msvc_rtf\10.pat flare_msvc_rtf\11.pat flare_msvc_rtf\12.pat flare_msvc_rtf\13.pat fl
are_msvc_rtf\14.pat flare_msvc_rtf\15.pat flare_msvc_rtf\16.pat flare_msvc_rtf\17.pat flare_msvc_rtf\18.pat flare_msvc_rtf\19.pat flare_msvc_rtf\20.pat flare_msvc_rtf\21.pat flare_msvc_rtf\22.pat flare_msvc_rtf\23.pat fl
are_msvc_rtf\24.pat flare_msvc_rtf\25.pat flare_msvc_rtf\26.pat flare_msvc_rtf\27.pat flare_msvc_rtf\28.pat flare_msvc_rtf\29.pat flare_msvc_rtf\30.pat flare_msvc_rtf\31.pat flare_msvc_rtf\32.pat flare_msvc_rtf\33.pat fl
are_msvc_rtf\34.pat flare_msvc_rtf\35.pat flare_msvc_rtf\36.pat flare_msvc_rtf\37.pat flare_msvc_rtf\38.pat flare_msvc_rtf\39.pat flare_msvc_rtf\40.pat flare_msvc_rtf\41.pat flare_msvc_rtf\42.pat flare_msvc_rtf\43.pat fl
are_msvc_rtf\44.pat flare_msvc_rtf\45.pat flare_msvc_rtf\46.pat flare_msvc_rtf\47.pat flare_msvc_rtf\48.pat flare_msvc_rtf\49.pat flare_msvc_rtf\50.pat flare_msvc_rtf\51.pat flare_msvc_rtf\52.pat flare_msvc_rtf\53.pat fl
are_msvc_rtf\54.pat flare_msvc_rtf\55.pat flare_msvc_rtf\56.pat flare_msvc_rtf\57.pat flare_msvc_rtf\58.pat flare_msvc_rtf\59.pat flare_msvc_rtf\60.pat flare_msvc_rtf\61.pat flare_msvc_rtf\62.pat flare_msvc_rtf\63.pat fl
are_msvc_rtf\64.pat flare_msvc_rtf\65.pat flare_msvc_rtf\66.pat flare_msvc_rtf\67.pat flare_msvc_rtf\68.pat flare_msvc_rtf\69.pat flare_msvc_rtf\70.pat flare_msvc_rtf\71.pat flare_msvc_rtf\72.pat flare_msvc_rtf\73.pat fl
are_msvc_rtf\74.pat flare_msvc_rtf\75.pat flare_msvc_rtf\76.pat flare_msvc_rtf\77.pat flare_msvc_rtf\78.pat flare_msvc_rtf\79.pat flare_msvc_rtf\80.pat flare_msvc_rtf\81.pat flare_msvc_rtf\82.pat flare_msvc_rtf\83.pat fl
are_msvc_rtf\84.pat flare_msvc_rtf\85.pat flare_msvc_rtf\86.pat flare_msvc_rtf\87.pat flare_msvc_rtf\88.pat flare_msvc_rtf\89.pat flare_msvc_rtf\90.pat flare_msvc_rtf\91.pat flare_msvc_rtf\92.pat flare_msvc_rtf\93.pat fl
are_msvc_rtf\94.pat flare_msvc_rtf\95.pat flare_msvc_rtf\96.pat flare_msvc_rtf\97.pat flare_msvc_rtf\98.pat flare_msvc_rtf\99.pat flare_msvc_rtf\100.pat flare_msvc_rtf\101.pat flare_msvc_rtf\102.pat flare_msvc_rtf\103.pa
t flare_msvc_rtf\104.pat flare_msvc_rtf\105.pat flare_msvc_rtf\106.pat flare_msvc_rtf\107.pat flare_msvc_rtf\108.pat flare_msvc_rtf\109.pat flare_msvc_rtf\110.pat flare_msvc_rtf\111.pat flare_msvc_rtf\112.pat flare_msvc_
rtf\113.pat flare_msvc_rtf\114.pat flare_msvc_rtf\115.pat flare_msvc_rtf\116.pat flare_msvc_rtf\117.pat flare_msvc_rtf\118.pat flare_msvc_rtf\119.pat flare_msvc_rtf\120.pat flare_msvc_rtf\121.pat flare_msvc_rtf\122.pat f
lare_msvc_rtf\123.pat flare_msvc_rtf\124.pat flare_msvc_rtf\125.pat flare_msvc_rtf\126.pat flare_msvc_rtf\127.pat flare_msvc_rtf\128.pat flare_msvc_rtf\129.pat flare_msvc_rtf\130.pat flare_msvc_rtf\131.pat flare_msvc_rtf
\132.pat flare_msvc_rtf\133.pat flare_msvc_rtf\134.pat flare_msvc_rtf\135.pat flare_msvc_rtf\136.pat flare_msvc_rtf\137.pat flare_msvc_rtf\138.pat flare_msvc_rtf\139.pat flare_msvc_rtf\140.pat flare_msvc_rtf\141.pat flar
e_msvc_rtf\142.pat flare_msvc_rtf\143.pat flare_msvc_rtf\144.pat flare_msvc_rtf\145.pat flare_msvc_rtf\146.pat flare_msvc_rtf\147.pat flare_msvc_rtf\148.pat flare_msvc_rtf\149.pat flare_msvc_rtf\150.pat flare_msvc_rtf\15
1.pat flare_msvc_rtf\152.pat flare_msvc_rtf\153.pat flare_msvc_rtf\154.pat flare_msvc_rtf\155.pat flare_msvc_rtf\156.pat flare_msvc_rtf\157.pat flare_msvc_rtf\158.pat flare_msvc_rtf\159.pat flare_msvc_rtf\160.pat flare_m
svc_rtf\161.pat flare_msvc_rtf\162.pat flare_msvc_rtf\163.pat flare_msvc_rtf\164.pat flare_msvc_rtf\165.pat flare_msvc_rtf\166.pat flare_msvc_rtf\167.pat flare_msvc_rtf\168.pat flare_msvc_rtf\169.pat flare_msvc_rtf\170.p
at flare_msvc_rtf\171.pat flare_msvc_rtf\172.pat flare_msvc_rtf\173.pat flare_msvc_rtf\174.pat flare_msvc_rtf\175.pat flare_msvc_rtf\176.pat flare_msvc_rtf\177.pat flare_msvc_rtf\178.pat flare_msvc_rtf\179.pat flare_msvc
_rtf\180.pat flare_msvc_rtf\181.pat flare_msvc_rtf\182.pat flare_msvc_rtf\183.pat flare_msvc_rtf\184.pat flare_msvc_rtf\185.pat flare_msvc_rtf\186.pat flare_msvc_rtf\187.pat flare_msvc_rtf\188.pat flare_msvc_rtf\189.pat
flare_msvc_rtf\190.pat flare_msvc_rtf\191.pat flare_msvc_rtf\192.pat flare_msvc_rtf\193.pat flare_msvc_rtf\194.pat flare_msvc_rtf\195.pat flare_msvc_rtf\196.pat flare_msvc_rtf\197.pat flare_msvc_rtf\198.pat flare_msvc_rt
f\199.pat flare_msvc_rtf\200.pat flare_msvc_rtf\201.pat flare_msvc_rtf\202.pat flare_msvc_rtf\203.pat flare_msvc_rtf\204.pat flare_msvc_rtf\205.pat flare_msvc_rtf\206.pat flare_msvc_rtf\207.pat flare_msvc_rtf\208.pat fla
re_msvc_rtf\209.pat flare_msvc_rtf\210.pat flare_msvc_rtf\211.pat flare_msvc_rtf\212.pat flare_msvc_rtf\213.pat flare_msvc_rtf\214.pat flare_msvc_rtf\215.pat flare_msvc_rtf\216.pat flare_msvc_rtf\217.pat flare_msvc_rtf\2
18.pat flare_msvc_rtf\219.pat flare_msvc_rtf\220.pat flare_msvc_rtf\221.pat flare_msvc_rtf\222.pat flare_msvc_rtf\223.pat flare_msvc_rtf\224.pat flare_msvc_rtf\225.pat flare_msvc_rtf\226.pat flare_msvc_rtf\227.pat flare_
msvc_rtf\228.pat flare_msvc_rtf\229.pat flare_msvc_rtf\230.pat flare_msvc_rtf\231.pat flare_msvc_rtf\232.pat flare_msvc_rtf\233.pat flare_msvc_rtf\234.pat flare_msvc_rtf\235.pat flare_msvc_rtf\236.pat flare_msvc_rtf\237.
pat flare_msvc_rtf\238.pat flare_msvc_rtf\239.pat flare_msvc_rtf\240.pat flare_msvc_rtf\241.pat flare_msvc_rtf\242.pat flare_msvc_rtf\243.pat flare_msvc_rtf\244.pat flare_msvc_rtf\245.pat flare_msvc_rtf\246.pat flare_msv
c_rtf\247.pat flare_msvc_rtf\248.pat flare_msvc_rtf\249.pat flare_msvc_rtf\250.pat flare_msvc_rtf\251.pat flare_msvc_rtf\252.pat flare_msvc_rtf\253.pat flare_msvc_rtf\254.pat flare_msvc_rtf\255.pat flare_msvc_rtf\256.pat
 flare_msvc_rtf\257.pat flare_msvc_rtf\258.pat flare_msvc_rtf\259.pat flare_msvc_rtf\260.pat flare_msvc_rtf\261.pat flare_msvc_rtf\262.pat flare_msvc_rtf\263.pat flare_msvc_rtf\264.pat flare_msvc_rtf\265.pat flare_msvc_r
tf\266.pat flare_msvc_rtf\267.pat flare_msvc_rtf\268.pat flare_msvc_rtf\269.pat flare_msvc_rtf\270.pat flare_msvc_rtf\271.pat flare_msvc_rtf\272.pat flare_msvc_rtf\273.pat flare_msvc_rtf\274.pat flare_msvc_rtf\275.pat fl
are_msvc_rtf\276.pat flare_msvc_rtf\277.pat flare_msvc_rtf\278.pat flare_msvc_rtf\279.pat flare_msvc_rtf\280.pat flare_msvc_rtf\281.pat flare_msvc_rtf\282.pat flare_msvc_rtf\283.pat flare_msvc_rtf\284.pat flare_msvc_rtf\
285.pat flare_msvc_rtf\286.pat flare_msvc_rtf\287.pat flare_msvc_rtf\288.pat flare_msvc_rtf\289.pat flare_msvc_rtf\290.pat flare_msvc_rtf\291.pat flare_msvc_rtf\292.pat flare_msvc_rtf\293.pat flare_msvc_rtf\294.pat flare
_msvc_rtf\295.pat flare_msvc_rtf\296.pat flare_msvc_rtf\297.pat flare_msvc_rtf\298.pat flare_msvc_rtf\299.pat flare_msvc_rtf\300.pat flare_msvc_rtf\301.pat flare_msvc_rtf\302.pat flare_msvc_rtf\303.pat flare_msvc_rtf\304
.pat flare_msvc_rtf\305.pat flare_msvc_rtf\306.pat flare_msvc_rtf\307.pat flare_msvc_rtf\308.pat flare_msvc_rtf\309.pat flare_msvc_rtf\310.pat flare_msvc_rtf\311.pat flare_msvc_rtf\312.pat flare_msvc_rtf\313.pat flare_ms
vc_rtf\314.pat flare_msvc_rtf\315.pat flare_msvc_rtf\316.pat flare_msvc_rtf\317.pat flare_msvc_rtf\318.pat flare_msvc_rtf\319.pat flare_msvc_rtf\320.pat flare_msvc_rtf\321.pat flare_msvc_rtf\322.pat flare_msvc_rtf\323.pa
t flare_msvc_rtf\324.pat flare_msvc_rtf\325.pat flare_msvc_rtf\326.pat flare_msvc_rtf\327.pat flare_msvc_rtf\328.pat flare_msvc_rtf\329.pat flare_msvc_rtf\330.pat flare_msvc_rtf\331.pat flare_msvc_rtf\332.pat flare_msvc_
rtf\333.pat flare_msvc_rtf\334.pat flare_msvc_rtf\335.pat flare_msvc_rtf\336.pat flare_msvc_rtf\337.pat flare_msvc_rtf\338.pat flare_msvc_rtf\339.pat flare_msvc_rtf\340.pat flare_msvc_rtf\341.pat flare_msvc_rtf\342.pat f
lare_msvc_rtf\343.pat flare_msvc_rtf\344.pat flare_msvc_rtf\345.pat flare_msvc_rtf\346.pat flare_msvc_rtf\347.pat flare_msvc_rtf\348.pat flare_msvc_rtf\349.pat flare_msvc_rtf\350.pat flare_msvc_rtf\351.pat flare_msvc_rtf
\352.pat flare_msvc_rtf\353.pat flare_msvc_rtf\354.pat flare_msvc_rtf\355.pat flare_msvc_rtf\356.pat flare_msvc_rtf\357.pat flare_msvc_rtf\358.pat flare_msvc_rtf\359.pat flare_msvc_rtf\360.pat flare_msvc_rtf\361.pat flar
e_msvc_rtf\362.pat flare_msvc_rtf\363.pat flare_msvc_rtf\364.pat flare_msvc_rtf\365.pat flare_msvc_rtf\366.pat flare_msvc_rtf\367.pat flare_msvc_rtf\368.pat flare_msvc_rtf\369.pat flare_msvc_rtf\370.pat flare_msvc_rtf\37
1.pat flare_msvc_rtf\372.pat flare_msvc_rtf\373.pat flare_msvc_rtf\374.pat flare_msvc_rtf\375.pat flare_msvc_rtf\376.pat flare_msvc_rtf\377.pat flare_msvc_rtf\378.pat flare_msvc_rtf\379.pat flare_msvc_rtf\380.pat flare_m
svc_rtf\381.pat flare_msvc_rtf\382.pat flare_msvc_rtf\383.pat flare_msvc_rtf\384.pat flare_msvc_rtf\flare_msvc_rtf_32_64.sig
DEBUG:__main__:running sigmake_patched.exe -v -v -n"FLARE MSVC Signatures" -lr\$LN -lrlabel flare_msvc_rtf\0.pat flare_msvc_rtf\1.pat flare_msvc_rtf\2.pat flare_msvc_rtf\3.
pat flare_msvc_rtf\4.pat flare_msvc_rtf\5.pat flare_msvc_rtf\6.pat flare_msvc_rtf\7.pat flare_msvc_rtf\8.pat flare_msvc_rtf\9.pat flare_msvc_rtf\10.pat flare_msvc_rtf\11.pat flare_msvc_rtf\12.pat flare_msvc_rtf\13.pat fl
are_msvc_rtf\14.pat flare_msvc_rtf\15.pat flare_msvc_rtf\16.pat flare_msvc_rtf\17.pat flare_msvc_rtf\18.pat flare_msvc_rtf\19.pat flare_msvc_rtf\20.pat flare_msvc_rtf\21.pat flare_msvc_rtf\22.pat flare_msvc_rtf\23.pat fl
are_msvc_rtf\24.pat flare_msvc_rtf\25.pat flare_msvc_rtf\26.pat flare_msvc_rtf\27.pat flare_msvc_rtf\28.pat flare_msvc_rtf\29.pat flare_msvc_rtf\30.pat flare_msvc_rtf\31.pat flare_msvc_rtf\32.pat flare_msvc_rtf\33.pat fl
are_msvc_rtf\34.pat flare_msvc_rtf\35.pat flare_msvc_rtf\36.pat flare_msvc_rtf\37.pat flare_msvc_rtf\38.pat flare_msvc_rtf\39.pat flare_msvc_rtf\40.pat flare_msvc_rtf\41.pat flare_msvc_rtf\42.pat flare_msvc_rtf\43.pat fl
are_msvc_rtf\44.pat flare_msvc_rtf\45.pat flare_msvc_rtf\46.pat flare_msvc_rtf\47.pat flare_msvc_rtf\48.pat flare_msvc_rtf\49.pat flare_msvc_rtf\50.pat flare_msvc_rtf\51.pat flare_msvc_rtf\52.pat flare_msvc_rtf\53.pat fl
are_msvc_rtf\54.pat flare_msvc_rtf\55.pat flare_msvc_rtf\56.pat flare_msvc_rtf\57.pat flare_msvc_rtf\58.pat flare_msvc_rtf\59.pat flare_msvc_rtf\60.pat flare_msvc_rtf\61.pat flare_msvc_rtf\62.pat flare_msvc_rtf\63.pat fl
are_msvc_rtf\64.pat flare_msvc_rtf\65.pat flare_msvc_rtf\66.pat flare_msvc_rtf\67.pat flare_msvc_rtf\68.pat flare_msvc_rtf\69.pat flare_msvc_rtf\70.pat flare_msvc_rtf\71.pat flare_msvc_rtf\72.pat flare_msvc_rtf\73.pat fl
are_msvc_rtf\74.pat flare_msvc_rtf\75.pat flare_msvc_rtf\76.pat flare_msvc_rtf\77.pat flare_msvc_rtf\78.pat flare_msvc_rtf\79.pat flare_msvc_rtf\80.pat flare_msvc_rtf\81.pat flare_msvc_rtf\82.pat flare_msvc_rtf\83.pat fl
are_msvc_rtf\84.pat flare_msvc_rtf\85.pat flare_msvc_rtf\86.pat flare_msvc_rtf\87.pat flare_msvc_rtf\88.pat flare_msvc_rtf\89.pat flare_msvc_rtf\90.pat flare_msvc_rtf\91.pat flare_msvc_rtf\92.pat flare_msvc_rtf\93.pat fl
are_msvc_rtf\94.pat flare_msvc_rtf\95.pat flare_msvc_rtf\96.pat flare_msvc_rtf\97.pat flare_msvc_rtf\98.pat flare_msvc_rtf\99.pat flare_msvc_rtf\100.pat flare_msvc_rtf\101.pat flare_msvc_rtf\102.pat flare_msvc_rtf\103.pa
t flare_msvc_rtf\104.pat flare_msvc_rtf\105.pat flare_msvc_rtf\106.pat flare_msvc_rtf\107.pat flare_msvc_rtf\108.pat flare_msvc_rtf\109.pat flare_msvc_rtf\110.pat flare_msvc_rtf\111.pat flare_msvc_rtf\112.pat flare_msvc_
rtf\113.pat flare_msvc_rtf\114.pat flare_msvc_rtf\115.pat flare_msvc_rtf\116.pat flare_msvc_rtf\117.pat flare_msvc_rtf\118.pat flare_msvc_rtf\119.pat flare_msvc_rtf\120.pat flare_msvc_rtf\121.pat flare_msvc_rtf\122.pat f
lare_msvc_rtf\123.pat flare_msvc_rtf\124.pat flare_msvc_rtf\125.pat flare_msvc_rtf\126.pat flare_msvc_rtf\127.pat flare_msvc_rtf\128.pat flare_msvc_rtf\129.pat flare_msvc_rtf\130.pat flare_msvc_rtf\131.pat flare_msvc_rtf
\132.pat flare_msvc_rtf\133.pat flare_msvc_rtf\134.pat flare_msvc_rtf\135.pat flare_msvc_rtf\136.pat flare_msvc_rtf\137.pat flare_msvc_rtf\138.pat flare_msvc_rtf\139.pat flare_msvc_rtf\140.pat flare_msvc_rtf\141.pat flar
e_msvc_rtf\142.pat flare_msvc_rtf\143.pat flare_msvc_rtf\144.pat flare_msvc_rtf\145.pat flare_msvc_rtf\146.pat flare_msvc_rtf\147.pat flare_msvc_rtf\148.pat flare_msvc_rtf\149.pat flare_msvc_rtf\150.pat flare_msvc_rtf\15
1.pat flare_msvc_rtf\152.pat flare_msvc_rtf\153.pat flare_msvc_rtf\154.pat flare_msvc_rtf\155.pat flare_msvc_rtf\156.pat flare_msvc_rtf\157.pat flare_msvc_rtf\158.pat flare_msvc_rtf\159.pat flare_msvc_rtf\160.pat flare_m
svc_rtf\161.pat flare_msvc_rtf\162.pat flare_msvc_rtf\163.pat flare_msvc_rtf\164.pat flare_msvc_rtf\165.pat flare_msvc_rtf\166.pat flare_msvc_rtf\167.pat flare_msvc_rtf\168.pat flare_msvc_rtf\169.pat flare_msvc_rtf\170.p
at flare_msvc_rtf\171.pat flare_msvc_rtf\172.pat flare_msvc_rtf\173.pat flare_msvc_rtf\174.pat flare_msvc_rtf\175.pat flare_msvc_rtf\176.pat flare_msvc_rtf\177.pat flare_msvc_rtf\178.pat flare_msvc_rtf\179.pat flare_msvc
_rtf\180.pat flare_msvc_rtf\181.pat flare_msvc_rtf\182.pat flare_msvc_rtf\183.pat flare_msvc_rtf\184.pat flare_msvc_rtf\185.pat flare_msvc_rtf\186.pat flare_msvc_rtf\187.pat flare_msvc_rtf\188.pat flare_msvc_rtf\189.pat
flare_msvc_rtf\190.pat flare_msvc_rtf\191.pat flare_msvc_rtf\192.pat flare_msvc_rtf\193.pat flare_msvc_rtf\194.pat flare_msvc_rtf\195.pat flare_msvc_rtf\196.pat flare_msvc_rtf\197.pat flare_msvc_rtf\198.pat flare_msvc_rt
f\199.pat flare_msvc_rtf\200.pat flare_msvc_rtf\201.pat flare_msvc_rtf\202.pat flare_msvc_rtf\203.pat flare_msvc_rtf\204.pat flare_msvc_rtf\205.pat flare_msvc_rtf\206.pat flare_msvc_rtf\207.pat flare_msvc_rtf\208.pat fla
re_msvc_rtf\209.pat flare_msvc_rtf\210.pat flare_msvc_rtf\211.pat flare_msvc_rtf\212.pat flare_msvc_rtf\213.pat flare_msvc_rtf\214.pat flare_msvc_rtf\215.pat flare_msvc_rtf\216.pat flare_msvc_rtf\217.pat flare_msvc_rtf\2
18.pat flare_msvc_rtf\219.pat flare_msvc_rtf\220.pat flare_msvc_rtf\221.pat flare_msvc_rtf\222.pat flare_msvc_rtf\223.pat flare_msvc_rtf\224.pat flare_msvc_rtf\225.pat flare_msvc_rtf\226.pat flare_msvc_rtf\227.pat flare_
msvc_rtf\228.pat flare_msvc_rtf\229.pat flare_msvc_rtf\230.pat flare_msvc_rtf\231.pat flare_msvc_rtf\232.pat flare_msvc_rtf\233.pat flare_msvc_rtf\234.pat flare_msvc_rtf\235.pat flare_msvc_rtf\236.pat flare_msvc_rtf\237.
pat flare_msvc_rtf\238.pat flare_msvc_rtf\239.pat flare_msvc_rtf\240.pat flare_msvc_rtf\241.pat flare_msvc_rtf\242.pat flare_msvc_rtf\243.pat flare_msvc_rtf\244.pat flare_msvc_rtf\245.pat flare_msvc_rtf\246.pat flare_msv
c_rtf\247.pat flare_msvc_rtf\248.pat flare_msvc_rtf\249.pat flare_msvc_rtf\250.pat flare_msvc_rtf\251.pat flare_msvc_rtf\252.pat flare_msvc_rtf\253.pat flare_msvc_rtf\254.pat flare_msvc_rtf\255.pat flare_msvc_rtf\256.pat
 flare_msvc_rtf\257.pat flare_msvc_rtf\258.pat flare_msvc_rtf\259.pat flare_msvc_rtf\260.pat flare_msvc_rtf\261.pat flare_msvc_rtf\262.pat flare_msvc_rtf\263.pat flare_msvc_rtf\264.pat flare_msvc_rtf\265.pat flare_msvc_r
tf\266.pat flare_msvc_rtf\267.pat flare_msvc_rtf\268.pat flare_msvc_rtf\269.pat flare_msvc_rtf\270.pat flare_msvc_rtf\271.pat flare_msvc_rtf\272.pat flare_msvc_rtf\273.pat flare_msvc_rtf\274.pat flare_msvc_rtf\275.pat fl
are_msvc_rtf\276.pat flare_msvc_rtf\277.pat flare_msvc_rtf\278.pat flare_msvc_rtf\279.pat flare_msvc_rtf\280.pat flare_msvc_rtf\281.pat flare_msvc_rtf\282.pat flare_msvc_rtf\283.pat flare_msvc_rtf\284.pat flare_msvc_rtf\
285.pat flare_msvc_rtf\286.pat flare_msvc_rtf\287.pat flare_msvc_rtf\288.pat flare_msvc_rtf\289.pat flare_msvc_rtf\290.pat flare_msvc_rtf\291.pat flare_msvc_rtf\292.pat flare_msvc_rtf\293.pat flare_msvc_rtf\294.pat flare
_msvc_rtf\295.pat flare_msvc_rtf\296.pat flare_msvc_rtf\297.pat flare_msvc_rtf\298.pat flare_msvc_rtf\299.pat flare_msvc_rtf\300.pat flare_msvc_rtf\301.pat flare_msvc_rtf\302.pat flare_msvc_rtf\303.pat flare_msvc_rtf\304
.pat flare_msvc_rtf\305.pat flare_msvc_rtf\306.pat flare_msvc_rtf\307.pat flare_msvc_rtf\308.pat flare_msvc_rtf\309.pat flare_msvc_rtf\310.pat flare_msvc_rtf\311.pat flare_msvc_rtf\312.pat flare_msvc_rtf\313.pat flare_ms
vc_rtf\314.pat flare_msvc_rtf\315.pat flare_msvc_rtf\316.pat flare_msvc_rtf\317.pat flare_msvc_rtf\318.pat flare_msvc_rtf\319.pat flare_msvc_rtf\320.pat flare_msvc_rtf\321.pat flare_msvc_rtf\322.pat flare_msvc_rtf\323.pa
t flare_msvc_rtf\324.pat flare_msvc_rtf\325.pat flare_msvc_rtf\326.pat flare_msvc_rtf\327.pat flare_msvc_rtf\328.pat flare_msvc_rtf\329.pat flare_msvc_rtf\330.pat flare_msvc_rtf\331.pat flare_msvc_rtf\332.pat flare_msvc_
rtf\333.pat flare_msvc_rtf\334.pat flare_msvc_rtf\335.pat flare_msvc_rtf\336.pat flare_msvc_rtf\337.pat flare_msvc_rtf\338.pat flare_msvc_rtf\339.pat flare_msvc_rtf\340.pat flare_msvc_rtf\341.pat flare_msvc_rtf\342.pat f
lare_msvc_rtf\343.pat flare_msvc_rtf\344.pat flare_msvc_rtf\345.pat flare_msvc_rtf\346.pat flare_msvc_rtf\347.pat flare_msvc_rtf\348.pat flare_msvc_rtf\349.pat flare_msvc_rtf\350.pat flare_msvc_rtf\351.pat flare_msvc_rtf
\352.pat flare_msvc_rtf\353.pat flare_msvc_rtf\354.pat flare_msvc_rtf\355.pat flare_msvc_rtf\356.pat flare_msvc_rtf\357.pat flare_msvc_rtf\358.pat flare_msvc_rtf\359.pat flare_msvc_rtf\360.pat flare_msvc_rtf\361.pat flar
e_msvc_rtf\362.pat flare_msvc_rtf\363.pat flare_msvc_rtf\364.pat flare_msvc_rtf\365.pat flare_msvc_rtf\366.pat flare_msvc_rtf\367.pat flare_msvc_rtf\368.pat flare_msvc_rtf\369.pat flare_msvc_rtf\370.pat flare_msvc_rtf\37
1.pat flare_msvc_rtf\372.pat flare_msvc_rtf\373.pat flare_msvc_rtf\374.pat flare_msvc_rtf\375.pat flare_msvc_rtf\376.pat flare_msvc_rtf\377.pat flare_msvc_rtf\378.pat flare_msvc_rtf\379.pat flare_msvc_rtf\380.pat flare_m
svc_rtf\381.pat flare_msvc_rtf\382.pat flare_msvc_rtf\383.pat flare_msvc_rtf\384.pat flare_msvc_rtf\flare_msvc_rtf_32_64.sig
DEBUG:__main__:removing temp files flare_msvc_rtf\0.pat, flare_msvc_rtf\1.pat, flare_msvc_rtf\2.pat, ...
INFO:__main__:zipping sig file flare_msvc_rtf\flare_msvc_rtf_32_64.sig
DEBUG:__main__:running zipsig.exe flare_msvc_rtf\flare_msvc_rtf_32_64.sig
```